### PR TITLE
[-] Ignore some code to lib work if there is order_with_respect_to

### DIFF
--- a/django_lexorank/models/ranked_model.py
+++ b/django_lexorank/models/ranked_model.py
@@ -48,9 +48,9 @@ class RankedModel(models.Model):
 
     @transaction.atomic
     def save(self, *args, **kwargs) -> None:
-        if self.order_with_respect_to:
-            if self.field_value_has_changed(self.order_with_respect_to):
-                self.rank = None  # type: ignore[assignment]
+        # if self.order_with_respect_to:
+        #     if self.field_value_has_changed(self.order_with_respect_to):
+        #         self.rank = None  # type: ignore[assignment]
 
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
Hi, looks like the code in model.save method not working well if using with "order_with_respect_to".
I think that we need to temporary disable it if there no plan to implement the ScheduleBalancing. We can handle it in the Django pre_save signal