### PR TITLE
Fix foreign key field comparison in `field_value_has_changed` method

### DIFF
--- a/django_lexorank/models/ranked_model.py
+++ b/django_lexorank/models/ranked_model.py
@@ -45,7 +45,7 @@ class RankedModel(models.Model):
         initial_value = self.__initial_values[field]
 
         if isinstance(current_value, models.Model):
-            return current_value.pk != initial_value
+            current_value = current_value.pk
 
         return current_value != initial_value
 

--- a/django_lexorank/models/ranked_model.py
+++ b/django_lexorank/models/ranked_model.py
@@ -41,10 +41,13 @@ class RankedModel(models.Model):
         if not self.pk or not self.__initial_values:
             return False
 
-        if getattr(self, field) != self.__initial_values[field]:
-            return True
+        current_value = getattr(self, field)
+        initial_value = self.__initial_values[field]
 
-        return False
+        if isinstance(current_value, models.Model):
+            return current_value.pk != initial_value
+
+        return current_value != initial_value
 
     @transaction.atomic
     def save(self, *args, **kwargs) -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -292,3 +292,32 @@ def test_rebalancing_is_scheduled_for_a_whole_list_if_it_dont_have_respected_obj
     # then
     for board in boards:
         assert board.rebalancing_scheduled()
+
+
+def test_field_value_has_changed_method_with_no_changes(board):
+    # then
+    assert not board.field_value_has_changed("name")
+
+
+def test_field_value_has_changed_method(board):
+    # when
+    board.name = "new name"
+
+    # then
+    assert board.field_value_has_changed("name")
+
+
+def test_field_value_has_changed_method_foreign_key_no_changes(task, board_factory):
+    # then
+    assert not task.field_value_has_changed("board")
+
+
+def test_field_value_has_changed_method_foreign_key(task, board_factory):
+    # given
+    new_board = board_factory.create()
+
+    # when
+    task.board = new_board
+
+    # then
+    assert task.field_value_has_changed("board")


### PR DESCRIPTION
## Changes
- Fix comparison logic for ForeignKey fields in field_value_has_changed method
- Before: Direct comparison between instance and pk always returned True
- After: Compare instance's pk with initial value after checking ForeignKey type

## Details
- Changed from directly comparing Model instance with pk value to 
  comparing instance's pk with stored initial value
- Improved change detection for order_with_respect_to field (ForeignKey) 
  in RankedModel

## Related Issue
- Fixes [#5](https://github.com/rozumdev/django-lexorank/issues/5): ForeignKey comparison issue in field_value_has_changed method